### PR TITLE
[TEST] Re-factor selection origin boundary anchor logic out of `RenderParagraph` and into selection delegate

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1503,8 +1503,6 @@ class _SelectableFragment
   TextPosition? _textSelectionStart;
   TextPosition? _textSelectionEnd;
 
-  bool _selectableContainsOriginTextBoundary = false;
-
   LayerLink? _startHandleLayerLink;
   LayerLink? _endHandleLayerLink;
 
@@ -1615,7 +1613,6 @@ class _SelectableFragment
         if (selectParagraph.absorb) {
           _handleSelectAll();
           result = SelectionResult.next;
-          _selectableContainsOriginTextBoundary = true;
         } else {
           result = _handleSelectParagraph(selectParagraph.globalPosition);
         }
@@ -1681,87 +1678,17 @@ class _SelectableFragment
         textBoundary.boundaryStart.offset >= range.start &&
             textBoundary.boundaryEnd.offset <= range.end,
       );
-      if (_selectableContainsOriginTextBoundary &&
-          existingSelectionStart != null &&
-          existingSelectionEnd != null) {
-        final isSamePosition = position.offset == existingSelectionEnd.offset;
-        final bool isSelectionInverted =
-            existingSelectionStart.offset > existingSelectionEnd.offset;
-        final bool shouldSwapEdges =
-            !isSamePosition &&
-            (isSelectionInverted != (position.offset > existingSelectionEnd.offset));
-        if (shouldSwapEdges) {
-          if (position.offset < existingSelectionEnd.offset) {
-            targetPosition = textBoundary.boundaryStart;
-          } else {
-            targetPosition = textBoundary.boundaryEnd;
-          }
-          // When the selection is inverted by the new position it is necessary to
-          // swap the start edge (moving edge) with the end edge (static edge) to
-          // maintain the origin text boundary within the selection.
-          final _TextBoundaryRecord localTextBoundary = getTextBoundary(existingSelectionEnd);
-          assert(
-            localTextBoundary.boundaryStart.offset >= range.start &&
-                localTextBoundary.boundaryEnd.offset <= range.end,
-          );
-          _setSelectionPosition(
-            existingSelectionEnd.offset == localTextBoundary.boundaryStart.offset
-                ? localTextBoundary.boundaryEnd
-                : localTextBoundary.boundaryStart,
-            isEnd: true,
-          );
+      if (existingSelectionEnd != null) {
+        // If the end edge exists and the start edge is being moved, then the
+        // start edge is moved to encompass the entire text boundary at the new position.
+        if (position.offset < existingSelectionEnd.offset) {
+          targetPosition = textBoundary.boundaryStart;
         } else {
-          if (position.offset < existingSelectionEnd.offset) {
-            targetPosition = textBoundary.boundaryStart;
-          } else if (position.offset > existingSelectionEnd.offset) {
-            targetPosition = textBoundary.boundaryEnd;
-          } else {
-            // Keep the origin text boundary in bounds when position is at the static edge.
-            targetPosition = existingSelectionStart;
-          }
+          targetPosition = textBoundary.boundaryEnd;
         }
       } else {
-        if (existingSelectionEnd != null) {
-          // If the end edge exists and the start edge is being moved, then the
-          // start edge is moved to encompass the entire text boundary at the new position.
-          if (position.offset < existingSelectionEnd.offset) {
-            targetPosition = textBoundary.boundaryStart;
-          } else {
-            targetPosition = textBoundary.boundaryEnd;
-          }
-        } else {
-          // Move the start edge to the closest text boundary.
-          targetPosition = _closestTextBoundary(textBoundary, position);
-        }
-      }
-    } else {
-      // The position is not contained within the current rect. The targetPosition
-      // will either be at the end or beginning of the current rect. See [SelectionUtils.adjustDragOffset]
-      // for a more in depth explanation on this adjustment.
-      if (_selectableContainsOriginTextBoundary &&
-          existingSelectionStart != null &&
-          existingSelectionEnd != null) {
-        // When the selection is inverted by the new position it is necessary to
-        // swap the start edge (moving edge) with the end edge (static edge) to
-        // maintain the origin text boundary within the selection.
-        final isSamePosition = position.offset == existingSelectionEnd.offset;
-        final bool isSelectionInverted =
-            existingSelectionStart.offset > existingSelectionEnd.offset;
-        final bool shouldSwapEdges =
-            !isSamePosition &&
-            (isSelectionInverted != (position.offset > existingSelectionEnd.offset));
-
-        if (shouldSwapEdges) {
-          final _TextBoundaryRecord localTextBoundary = getTextBoundary(existingSelectionEnd);
-          assert(
-            localTextBoundary.boundaryStart.offset >= range.start &&
-                localTextBoundary.boundaryEnd.offset <= range.end,
-          );
-          _setSelectionPosition(
-            isSelectionInverted ? localTextBoundary.boundaryEnd : localTextBoundary.boundaryStart,
-            isEnd: true,
-          );
-        }
+        // Move the start edge to the closest text boundary.
+        targetPosition = _closestTextBoundary(textBoundary, position);
       }
     }
     return targetPosition ?? position;
@@ -1780,86 +1707,17 @@ class _SelectableFragment
         textBoundary.boundaryStart.offset >= range.start &&
             textBoundary.boundaryEnd.offset <= range.end,
       );
-      if (_selectableContainsOriginTextBoundary &&
-          existingSelectionStart != null &&
-          existingSelectionEnd != null) {
-        final isSamePosition = position.offset == existingSelectionStart.offset;
-        final bool isSelectionInverted =
-            existingSelectionStart.offset > existingSelectionEnd.offset;
-        final bool shouldSwapEdges =
-            !isSamePosition &&
-            (isSelectionInverted != (position.offset < existingSelectionStart.offset));
-        if (shouldSwapEdges) {
-          if (position.offset < existingSelectionStart.offset) {
-            targetPosition = textBoundary.boundaryStart;
-          } else {
-            targetPosition = textBoundary.boundaryEnd;
-          }
-          // When the selection is inverted by the new position it is necessary to
-          // swap the end edge (moving edge) with the start edge (static edge) to
-          // maintain the origin text boundary within the selection.
-          final _TextBoundaryRecord localTextBoundary = getTextBoundary(existingSelectionStart);
-          assert(
-            localTextBoundary.boundaryStart.offset >= range.start &&
-                localTextBoundary.boundaryEnd.offset <= range.end,
-          );
-          _setSelectionPosition(
-            existingSelectionStart.offset == localTextBoundary.boundaryStart.offset
-                ? localTextBoundary.boundaryEnd
-                : localTextBoundary.boundaryStart,
-            isEnd: false,
-          );
+      if (existingSelectionStart != null) {
+        // If the start edge exists and the end edge is being moved, then the
+        // end edge is moved to encompass the entire text boundary at the new position.
+        if (position.offset < existingSelectionStart.offset) {
+          targetPosition = textBoundary.boundaryStart;
         } else {
-          if (position.offset < existingSelectionStart.offset) {
-            targetPosition = textBoundary.boundaryStart;
-          } else if (position.offset > existingSelectionStart.offset) {
-            targetPosition = textBoundary.boundaryEnd;
-          } else {
-            // Keep the origin text boundary in bounds when position is at the static edge.
-            targetPosition = existingSelectionEnd;
-          }
+          targetPosition = textBoundary.boundaryEnd;
         }
       } else {
-        if (existingSelectionStart != null) {
-          // If the start edge exists and the end edge is being moved, then the
-          // end edge is moved to encompass the entire text boundary at the new position.
-          if (position.offset < existingSelectionStart.offset) {
-            targetPosition = textBoundary.boundaryStart;
-          } else {
-            targetPosition = textBoundary.boundaryEnd;
-          }
-        } else {
-          // Move the end edge to the closest text boundary.
-          targetPosition = _closestTextBoundary(textBoundary, position);
-        }
-      }
-    } else {
-      // The position is not contained within the current rect. The targetPosition
-      // will either be at the end or beginning of the current rect. See [SelectionUtils.adjustDragOffset]
-      // for a more in depth explanation on this adjustment.
-      if (_selectableContainsOriginTextBoundary &&
-          existingSelectionStart != null &&
-          existingSelectionEnd != null) {
-        // When the selection is inverted by the new position it is necessary to
-        // swap the end edge (moving edge) with the start edge (static edge) to
-        // maintain the origin text boundary within the selection.
-        final isSamePosition = position.offset == existingSelectionStart.offset;
-        final bool isSelectionInverted =
-            existingSelectionStart.offset > existingSelectionEnd.offset;
-        final bool shouldSwapEdges =
-            isSelectionInverted != (position.offset < existingSelectionStart.offset) ||
-            isSamePosition;
-        if (shouldSwapEdges) {
-          final _TextBoundaryRecord localTextBoundary = getTextBoundary(existingSelectionStart);
-          assert(
-            localTextBoundary.boundaryStart.offset >= range.start &&
-                localTextBoundary.boundaryEnd.offset <= range.end,
-          );
-          _setSelectionPosition(
-            isSelectionInverted ? localTextBoundary.boundaryStart : localTextBoundary.boundaryEnd,
-            isEnd: false,
-          );
-        }
+        // Move the end edge to the closest text boundary.
+        targetPosition = _closestTextBoundary(textBoundary, position);
       }
     }
     return targetPosition ?? position;
@@ -1991,10 +1849,6 @@ class _SelectableFragment
   // that a boundary spans multiple selectable fragments when the text contains
   // [WidgetSpan]s.
   //
-  // This method differs from [_updateSelectionStartEdgeByTextBoundary] in that
-  // to pivot offset used to swap selection edges and maintain the origin
-  // text boundary selected may be located outside of this selectable fragment.
-  //
   // See [_updateSelectionEndEdgeByMultiSelectableTextBoundary] for the method
   // that handles updating the end edge.
   SelectionResult? _updateSelectionStartEdgeByMultiSelectableTextBoundary(
@@ -2005,115 +1859,7 @@ class _SelectableFragment
     TextPosition? existingSelectionEnd,
   ) {
     const isEnd = false;
-    if (_selectableContainsOriginTextBoundary &&
-        existingSelectionStart != null &&
-        existingSelectionEnd != null) {
-      // If this selectable contains the origin boundary, maintain the existing
-      // selection.
-      final bool forwardSelection = existingSelectionEnd.offset >= existingSelectionStart.offset;
-      if (paragraphContainsPosition) {
-        // When the position is within the root paragraph, swap the start and end
-        // edges when the selection is inverted.
-        final _TextBoundaryRecord boundaryAtPosition = getTextBoundary(position, fullText);
-        // To accurately retrieve the origin text boundary when the selection
-        // is forward, use existingSelectionEnd.offset - 1. This is necessary
-        // because in a forwards selection, existingSelectionEnd marks the end
-        // of the origin text boundary. Using the unmodified offset incorrectly
-        // targets the subsequent text boundary.
-        final _TextBoundaryRecord originTextBoundary = getTextBoundary(
-          forwardSelection
-              ? TextPosition(
-                  offset: existingSelectionEnd.offset - 1,
-                  affinity: existingSelectionEnd.affinity,
-                )
-              : existingSelectionEnd,
-          fullText,
-        );
-        final TextPosition targetPosition;
-        final int pivotOffset = forwardSelection
-            ? originTextBoundary.boundaryEnd.offset
-            : originTextBoundary.boundaryStart.offset;
-        final shouldSwapEdges = !forwardSelection != (position.offset > pivotOffset);
-        if (position.offset < pivotOffset) {
-          targetPosition = boundaryAtPosition.boundaryStart;
-        } else if (position.offset > pivotOffset) {
-          targetPosition = boundaryAtPosition.boundaryEnd;
-        } else {
-          // Keep the origin text boundary in bounds when position is at the static edge.
-          targetPosition = forwardSelection ? existingSelectionStart : existingSelectionEnd;
-        }
-        if (shouldSwapEdges) {
-          _setSelectionPosition(
-            _clampTextPosition(
-              forwardSelection ? originTextBoundary.boundaryStart : originTextBoundary.boundaryEnd,
-            ),
-            isEnd: true,
-          );
-        }
-        _setSelectionPosition(_clampTextPosition(targetPosition), isEnd: isEnd);
-        final bool finalSelectionIsForward =
-            _textSelectionEnd!.offset >= _textSelectionStart!.offset;
-        if (boundaryAtPosition.boundaryStart.offset > range.end &&
-            boundaryAtPosition.boundaryEnd.offset > range.end) {
-          return SelectionResult.next;
-        }
-        if (boundaryAtPosition.boundaryStart.offset < range.start &&
-            boundaryAtPosition.boundaryEnd.offset < range.start) {
-          return SelectionResult.previous;
-        }
-        if (finalSelectionIsForward) {
-          if (boundaryAtPosition.boundaryStart.offset >= originTextBoundary.boundaryStart.offset) {
-            return SelectionResult.end;
-          }
-          if (boundaryAtPosition.boundaryStart.offset < originTextBoundary.boundaryStart.offset) {
-            return SelectionResult.previous;
-          }
-        } else {
-          if (boundaryAtPosition.boundaryEnd.offset <= originTextBoundary.boundaryEnd.offset) {
-            return SelectionResult.end;
-          }
-          if (boundaryAtPosition.boundaryEnd.offset > originTextBoundary.boundaryEnd.offset) {
-            return SelectionResult.next;
-          }
-        }
-      } else {
-        // When the drag position is not contained within the root paragraph,
-        // swap the edges when the selection changes direction.
-        final TextPosition clampedPosition = _clampTextPosition(position);
-        // To accurately retrieve the origin text boundary when the selection
-        // is forward, use existingSelectionEnd.offset - 1. This is necessary
-        // because in a forwards selection, existingSelectionEnd marks the end
-        // of the origin text boundary. Using the unmodified offset incorrectly
-        // targets the subsequent text boundary.
-        final _TextBoundaryRecord originTextBoundary = getTextBoundary(
-          forwardSelection
-              ? TextPosition(
-                  offset: existingSelectionEnd.offset - 1,
-                  affinity: existingSelectionEnd.affinity,
-                )
-              : existingSelectionEnd,
-          fullText,
-        );
-        if (forwardSelection && clampedPosition.offset == range.start) {
-          _setSelectionPosition(clampedPosition, isEnd: isEnd);
-          return SelectionResult.previous;
-        }
-        if (!forwardSelection && clampedPosition.offset == range.end) {
-          _setSelectionPosition(clampedPosition, isEnd: isEnd);
-          return SelectionResult.next;
-        }
-        if (forwardSelection && clampedPosition.offset == range.end) {
-          _setSelectionPosition(_clampTextPosition(originTextBoundary.boundaryStart), isEnd: true);
-          _setSelectionPosition(clampedPosition, isEnd: isEnd);
-          return SelectionResult.next;
-        }
-        if (!forwardSelection && clampedPosition.offset == range.start) {
-          _setSelectionPosition(_clampTextPosition(originTextBoundary.boundaryEnd), isEnd: true);
-          _setSelectionPosition(clampedPosition, isEnd: isEnd);
-          return SelectionResult.previous;
-        }
-      }
-    } else {
+    {
       // A paragraph boundary may not be completely contained within this root
       // selectable fragment. Keep searching until we find the end of the
       // boundary. Do not search when the current drag position is on a placeholder
@@ -2169,12 +1915,8 @@ class _SelectableFragment
   // that a boundary spans multiple selectable fragments when the text contains
   // [WidgetSpan]s.
   //
-  // This method differs from [_updateSelectionEndEdgeByTextBoundary] in that
-  // to pivot offset used to swap selection edges and maintain the origin
-  // text boundary selected may be located outside of this selectable fragment.
-  //
   // See [_updateSelectionStartEdgeByMultiSelectableTextBoundary] for the method
-  // that handles updating the end edge.
+  // that handles updating the start edge.
   SelectionResult? _updateSelectionEndEdgeByMultiSelectableTextBoundary(
     _TextBoundaryAtPositionInText getTextBoundary,
     bool paragraphContainsPosition,
@@ -2183,115 +1925,7 @@ class _SelectableFragment
     TextPosition? existingSelectionEnd,
   ) {
     const isEnd = true;
-    if (_selectableContainsOriginTextBoundary &&
-        existingSelectionStart != null &&
-        existingSelectionEnd != null) {
-      // If this selectable contains the origin boundary, maintain the existing
-      // selection.
-      final bool forwardSelection = existingSelectionEnd.offset >= existingSelectionStart.offset;
-      if (paragraphContainsPosition) {
-        // When the position is within the root paragraph, swap the start and end
-        // edges when the selection is inverted.
-        final _TextBoundaryRecord boundaryAtPosition = getTextBoundary(position, fullText);
-        // To accurately retrieve the origin text boundary when the selection
-        // is backwards, use existingSelectionStart.offset - 1. This is necessary
-        // because in a backwards selection, existingSelectionStart marks the end
-        // of the origin text boundary. Using the unmodified offset incorrectly
-        // targets the subsequent text boundary.
-        final _TextBoundaryRecord originTextBoundary = getTextBoundary(
-          forwardSelection
-              ? existingSelectionStart
-              : TextPosition(
-                  offset: existingSelectionStart.offset - 1,
-                  affinity: existingSelectionStart.affinity,
-                ),
-          fullText,
-        );
-        final TextPosition targetPosition;
-        final int pivotOffset = forwardSelection
-            ? originTextBoundary.boundaryStart.offset
-            : originTextBoundary.boundaryEnd.offset;
-        final shouldSwapEdges = !forwardSelection != (position.offset < pivotOffset);
-        if (position.offset < pivotOffset) {
-          targetPosition = boundaryAtPosition.boundaryStart;
-        } else if (position.offset > pivotOffset) {
-          targetPosition = boundaryAtPosition.boundaryEnd;
-        } else {
-          // Keep the origin text boundary in bounds when position is at the static edge.
-          targetPosition = forwardSelection ? existingSelectionEnd : existingSelectionStart;
-        }
-        if (shouldSwapEdges) {
-          _setSelectionPosition(
-            _clampTextPosition(
-              forwardSelection ? originTextBoundary.boundaryEnd : originTextBoundary.boundaryStart,
-            ),
-            isEnd: false,
-          );
-        }
-        _setSelectionPosition(_clampTextPosition(targetPosition), isEnd: isEnd);
-        final bool finalSelectionIsForward =
-            _textSelectionEnd!.offset >= _textSelectionStart!.offset;
-        if (boundaryAtPosition.boundaryStart.offset > range.end &&
-            boundaryAtPosition.boundaryEnd.offset > range.end) {
-          return SelectionResult.next;
-        }
-        if (boundaryAtPosition.boundaryStart.offset < range.start &&
-            boundaryAtPosition.boundaryEnd.offset < range.start) {
-          return SelectionResult.previous;
-        }
-        if (finalSelectionIsForward) {
-          if (boundaryAtPosition.boundaryEnd.offset <= originTextBoundary.boundaryEnd.offset) {
-            return SelectionResult.end;
-          }
-          if (boundaryAtPosition.boundaryEnd.offset > originTextBoundary.boundaryEnd.offset) {
-            return SelectionResult.next;
-          }
-        } else {
-          if (boundaryAtPosition.boundaryStart.offset >= originTextBoundary.boundaryStart.offset) {
-            return SelectionResult.end;
-          }
-          if (boundaryAtPosition.boundaryStart.offset < originTextBoundary.boundaryStart.offset) {
-            return SelectionResult.previous;
-          }
-        }
-      } else {
-        // When the drag position is not contained within the root paragraph,
-        // swap the edges when the selection changes direction.
-        final TextPosition clampedPosition = _clampTextPosition(position);
-        // To accurately retrieve the origin text boundary when the selection
-        // is backwards, use existingSelectionStart.offset - 1. This is necessary
-        // because in a backwards selection, existingSelectionStart marks the end
-        // of the origin text boundary. Using the unmodified offset incorrectly
-        // targets the subsequent text boundary.
-        final _TextBoundaryRecord originTextBoundary = getTextBoundary(
-          forwardSelection
-              ? existingSelectionStart
-              : TextPosition(
-                  offset: existingSelectionStart.offset - 1,
-                  affinity: existingSelectionStart.affinity,
-                ),
-          fullText,
-        );
-        if (forwardSelection && clampedPosition.offset == range.start) {
-          _setSelectionPosition(_clampTextPosition(originTextBoundary.boundaryEnd), isEnd: false);
-          _setSelectionPosition(clampedPosition, isEnd: isEnd);
-          return SelectionResult.previous;
-        }
-        if (!forwardSelection && clampedPosition.offset == range.end) {
-          _setSelectionPosition(_clampTextPosition(originTextBoundary.boundaryStart), isEnd: false);
-          _setSelectionPosition(clampedPosition, isEnd: isEnd);
-          return SelectionResult.next;
-        }
-        if (forwardSelection && clampedPosition.offset == range.end) {
-          _setSelectionPosition(clampedPosition, isEnd: isEnd);
-          return SelectionResult.next;
-        }
-        if (!forwardSelection && clampedPosition.offset == range.start) {
-          _setSelectionPosition(clampedPosition, isEnd: isEnd);
-          return SelectionResult.previous;
-        }
-      }
-    } else {
+    {
       // A paragraph boundary may not be completely contained within this root
       // selectable fragment. Keep searching until we find the end of the
       // boundary. Do not search when the current drag position is on a placeholder
@@ -2353,11 +1987,6 @@ class _SelectableFragment
   // that a boundary spans multiple selectable fragments when the text contains
   // [WidgetSpan]s.
   //
-  // This method differs from [_updateSelectionStartEdgeByMultiSelectableBoundary]
-  // in that to maintain the origin text boundary selected at a placeholder,
-  // this selectable fragment must be aware of the [RenderParagraph] that closely
-  // encompasses the complete origin text boundary.
-  //
   // See [_updateSelectionEndEdgeAtPlaceholderByMultiSelectableTextBoundary] for the method
   // that handles updating the end edge.
   SelectionResult? _updateSelectionStartEdgeAtPlaceholderByMultiSelectableTextBoundary(
@@ -2369,147 +1998,7 @@ class _SelectableFragment
     TextPosition? existingSelectionEnd,
   ) {
     const isEnd = false;
-    if (_selectableContainsOriginTextBoundary &&
-        existingSelectionStart != null &&
-        existingSelectionEnd != null) {
-      // If this selectable contains the origin boundary, maintain the existing
-      // selection.
-      final bool forwardSelection = existingSelectionEnd.offset >= existingSelectionStart.offset;
-      final RenderParagraph originParagraph = _getOriginParagraph();
-      final fragmentBelongsToOriginParagraph = originParagraph == paragraph;
-      if (fragmentBelongsToOriginParagraph) {
-        return _updateSelectionStartEdgeByMultiSelectableTextBoundary(
-          getTextBoundary,
-          paragraphContainsPosition,
-          position,
-          existingSelectionStart,
-          existingSelectionEnd,
-        );
-      }
-      final Matrix4 originTransform = originParagraph.getTransformTo(null);
-      originTransform.invert();
-      final Offset originParagraphLocalPosition = MatrixUtils.transformPoint(
-        originTransform,
-        globalPosition,
-      );
-      final bool positionWithinOriginParagraph = originParagraph.paintBounds.contains(
-        originParagraphLocalPosition,
-      );
-      final TextPosition positionRelativeToOriginParagraph = originParagraph.getPositionForOffset(
-        originParagraphLocalPosition,
-      );
-      if (positionWithinOriginParagraph) {
-        // When the selection is inverted by the new position it is necessary to
-        // swap the start edge (moving edge) with the end edge (static edge) to
-        // maintain the origin text boundary within the selection.
-        final String originText = originParagraph.text.toPlainText(includeSemanticsLabels: false);
-        final _TextBoundaryRecord boundaryAtPosition = getTextBoundary(
-          positionRelativeToOriginParagraph,
-          originText,
-        );
-        final _TextBoundaryRecord originTextBoundary = getTextBoundary(
-          _getPositionInParagraph(originParagraph),
-          originText,
-        );
-        final TextPosition targetPosition;
-        final int pivotOffset = forwardSelection
-            ? originTextBoundary.boundaryEnd.offset
-            : originTextBoundary.boundaryStart.offset;
-        final shouldSwapEdges =
-            !forwardSelection != (positionRelativeToOriginParagraph.offset > pivotOffset);
-        if (positionRelativeToOriginParagraph.offset < pivotOffset) {
-          targetPosition = boundaryAtPosition.boundaryStart;
-        } else if (positionRelativeToOriginParagraph.offset > pivotOffset) {
-          targetPosition = boundaryAtPosition.boundaryEnd;
-        } else {
-          // Keep the origin text boundary in bounds when position is at the static edge.
-          targetPosition = existingSelectionStart;
-        }
-        if (shouldSwapEdges) {
-          _setSelectionPosition(existingSelectionStart, isEnd: true);
-        }
-        _setSelectionPosition(_clampTextPosition(targetPosition), isEnd: isEnd);
-        final bool finalSelectionIsForward =
-            _textSelectionEnd!.offset >= _textSelectionStart!.offset;
-        final TextPosition originParagraphPlaceholderTextPosition = _getPositionInParagraph(
-          originParagraph,
-        );
-        final originParagraphPlaceholderRange = TextRange(
-          start: originParagraphPlaceholderTextPosition.offset,
-          end: originParagraphPlaceholderTextPosition.offset + _placeholderLength,
-        );
-        if (boundaryAtPosition.boundaryStart.offset > originParagraphPlaceholderRange.end &&
-            boundaryAtPosition.boundaryEnd.offset > originParagraphPlaceholderRange.end) {
-          return SelectionResult.next;
-        }
-        if (boundaryAtPosition.boundaryStart.offset < originParagraphPlaceholderRange.start &&
-            boundaryAtPosition.boundaryEnd.offset < originParagraphPlaceholderRange.start) {
-          return SelectionResult.previous;
-        }
-        if (finalSelectionIsForward) {
-          if (boundaryAtPosition.boundaryEnd.offset <= originTextBoundary.boundaryEnd.offset) {
-            return SelectionResult.end;
-          }
-          if (boundaryAtPosition.boundaryEnd.offset > originTextBoundary.boundaryEnd.offset) {
-            return SelectionResult.next;
-          }
-        } else {
-          if (boundaryAtPosition.boundaryStart.offset >= originTextBoundary.boundaryStart.offset) {
-            return SelectionResult.end;
-          }
-          if (boundaryAtPosition.boundaryStart.offset < originTextBoundary.boundaryStart.offset) {
-            return SelectionResult.previous;
-          }
-        }
-      } else {
-        // When the drag position is not contained within the origin paragraph,
-        // swap the edges when the selection changes direction.
-        //
-        // [SelectionUtils.adjustDragOffset] will adjust the given [Offset] to the
-        // beginning or end of the provided [Rect] based on whether the [Offset]
-        // is located within the given [Rect].
-        final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
-          originParagraph.paintBounds,
-          originParagraphLocalPosition,
-          direction: paragraph.textDirection,
-        );
-        final TextPosition adjustedPositionRelativeToOriginParagraph = originParagraph
-            .getPositionForOffset(adjustedOffset);
-        final TextPosition originParagraphPlaceholderTextPosition = _getPositionInParagraph(
-          originParagraph,
-        );
-        final originParagraphPlaceholderRange = TextRange(
-          start: originParagraphPlaceholderTextPosition.offset,
-          end: originParagraphPlaceholderTextPosition.offset + _placeholderLength,
-        );
-        if (forwardSelection &&
-            adjustedPositionRelativeToOriginParagraph.offset <=
-                originParagraphPlaceholderRange.start) {
-          _setSelectionPosition(TextPosition(offset: range.start), isEnd: isEnd);
-          return SelectionResult.previous;
-        }
-        if (!forwardSelection &&
-            adjustedPositionRelativeToOriginParagraph.offset >=
-                originParagraphPlaceholderRange.end) {
-          _setSelectionPosition(TextPosition(offset: range.end), isEnd: isEnd);
-          return SelectionResult.next;
-        }
-        if (forwardSelection &&
-            adjustedPositionRelativeToOriginParagraph.offset >=
-                originParagraphPlaceholderRange.end) {
-          _setSelectionPosition(existingSelectionStart, isEnd: true);
-          _setSelectionPosition(TextPosition(offset: range.end), isEnd: isEnd);
-          return SelectionResult.next;
-        }
-        if (!forwardSelection &&
-            adjustedPositionRelativeToOriginParagraph.offset <=
-                originParagraphPlaceholderRange.start) {
-          _setSelectionPosition(existingSelectionStart, isEnd: true);
-          _setSelectionPosition(TextPosition(offset: range.start), isEnd: isEnd);
-          return SelectionResult.previous;
-        }
-      }
-    } else {
+    {
       // When the drag position is somewhere on the root text and not a placeholder,
       // traverse the selectable fragments relative to the [RenderParagraph] that
       // contains the drag position.
@@ -2605,11 +2094,6 @@ class _SelectableFragment
   // that a boundary spans multiple selectable fragments when the text contains
   // [WidgetSpan]s.
   //
-  // This method differs from [_updateSelectionEndEdgeByMultiSelectableBoundary]
-  // in that to maintain the origin text boundary selected at a placeholder, this
-  // selectable fragment must be aware of the [RenderParagraph] that closely
-  // encompasses the complete origin text boundary.
-  //
   // See [_updateSelectionStartEdgeAtPlaceholderByMultiSelectableTextBoundary]
   // for the method that handles updating the start edge.
   SelectionResult? _updateSelectionEndEdgeAtPlaceholderByMultiSelectableTextBoundary(
@@ -2621,147 +2105,7 @@ class _SelectableFragment
     TextPosition? existingSelectionEnd,
   ) {
     const isEnd = true;
-    if (_selectableContainsOriginTextBoundary &&
-        existingSelectionStart != null &&
-        existingSelectionEnd != null) {
-      // If this selectable contains the origin boundary, maintain the existing
-      // selection.
-      final bool forwardSelection = existingSelectionEnd.offset >= existingSelectionStart.offset;
-      final RenderParagraph originParagraph = _getOriginParagraph();
-      final fragmentBelongsToOriginParagraph = originParagraph == paragraph;
-      if (fragmentBelongsToOriginParagraph) {
-        return _updateSelectionEndEdgeByMultiSelectableTextBoundary(
-          getTextBoundary,
-          paragraphContainsPosition,
-          position,
-          existingSelectionStart,
-          existingSelectionEnd,
-        );
-      }
-      final Matrix4 originTransform = originParagraph.getTransformTo(null);
-      originTransform.invert();
-      final Offset originParagraphLocalPosition = MatrixUtils.transformPoint(
-        originTransform,
-        globalPosition,
-      );
-      final bool positionWithinOriginParagraph = originParagraph.paintBounds.contains(
-        originParagraphLocalPosition,
-      );
-      final TextPosition positionRelativeToOriginParagraph = originParagraph.getPositionForOffset(
-        originParagraphLocalPosition,
-      );
-      if (positionWithinOriginParagraph) {
-        // When the selection is inverted by the new position it is necessary to
-        // swap the end edge (moving edge) with the start edge (static edge) to
-        // maintain the origin text boundary within the selection.
-        final String originText = originParagraph.text.toPlainText(includeSemanticsLabels: false);
-        final _TextBoundaryRecord boundaryAtPosition = getTextBoundary(
-          positionRelativeToOriginParagraph,
-          originText,
-        );
-        final _TextBoundaryRecord originTextBoundary = getTextBoundary(
-          _getPositionInParagraph(originParagraph),
-          originText,
-        );
-        final TextPosition targetPosition;
-        final int pivotOffset = forwardSelection
-            ? originTextBoundary.boundaryStart.offset
-            : originTextBoundary.boundaryEnd.offset;
-        final shouldSwapEdges =
-            !forwardSelection != (positionRelativeToOriginParagraph.offset < pivotOffset);
-        if (positionRelativeToOriginParagraph.offset < pivotOffset) {
-          targetPosition = boundaryAtPosition.boundaryStart;
-        } else if (positionRelativeToOriginParagraph.offset > pivotOffset) {
-          targetPosition = boundaryAtPosition.boundaryEnd;
-        } else {
-          // Keep the origin text boundary in bounds when position is at the static edge.
-          targetPosition = existingSelectionEnd;
-        }
-        if (shouldSwapEdges) {
-          _setSelectionPosition(existingSelectionEnd, isEnd: false);
-        }
-        _setSelectionPosition(_clampTextPosition(targetPosition), isEnd: isEnd);
-        final bool finalSelectionIsForward =
-            _textSelectionEnd!.offset >= _textSelectionStart!.offset;
-        final TextPosition originParagraphPlaceholderTextPosition = _getPositionInParagraph(
-          originParagraph,
-        );
-        final originParagraphPlaceholderRange = TextRange(
-          start: originParagraphPlaceholderTextPosition.offset,
-          end: originParagraphPlaceholderTextPosition.offset + _placeholderLength,
-        );
-        if (boundaryAtPosition.boundaryStart.offset > originParagraphPlaceholderRange.end &&
-            boundaryAtPosition.boundaryEnd.offset > originParagraphPlaceholderRange.end) {
-          return SelectionResult.next;
-        }
-        if (boundaryAtPosition.boundaryStart.offset < originParagraphPlaceholderRange.start &&
-            boundaryAtPosition.boundaryEnd.offset < originParagraphPlaceholderRange.start) {
-          return SelectionResult.previous;
-        }
-        if (finalSelectionIsForward) {
-          if (boundaryAtPosition.boundaryEnd.offset <= originTextBoundary.boundaryEnd.offset) {
-            return SelectionResult.end;
-          }
-          if (boundaryAtPosition.boundaryEnd.offset > originTextBoundary.boundaryEnd.offset) {
-            return SelectionResult.next;
-          }
-        } else {
-          if (boundaryAtPosition.boundaryStart.offset >= originTextBoundary.boundaryStart.offset) {
-            return SelectionResult.end;
-          }
-          if (boundaryAtPosition.boundaryStart.offset < originTextBoundary.boundaryStart.offset) {
-            return SelectionResult.previous;
-          }
-        }
-      } else {
-        // When the drag position is not contained within the origin paragraph,
-        // swap the edges when the selection changes direction.
-        //
-        // [SelectionUtils.adjustDragOffset] will adjust the given [Offset] to the
-        // beginning or end of the provided [Rect] based on whether the [Offset]
-        // is located within the given [Rect].
-        final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
-          originParagraph.paintBounds,
-          originParagraphLocalPosition,
-          direction: paragraph.textDirection,
-        );
-        final TextPosition adjustedPositionRelativeToOriginParagraph = originParagraph
-            .getPositionForOffset(adjustedOffset);
-        final TextPosition originParagraphPlaceholderTextPosition = _getPositionInParagraph(
-          originParagraph,
-        );
-        final originParagraphPlaceholderRange = TextRange(
-          start: originParagraphPlaceholderTextPosition.offset,
-          end: originParagraphPlaceholderTextPosition.offset + _placeholderLength,
-        );
-        if (forwardSelection &&
-            adjustedPositionRelativeToOriginParagraph.offset <=
-                originParagraphPlaceholderRange.start) {
-          _setSelectionPosition(existingSelectionEnd, isEnd: false);
-          _setSelectionPosition(TextPosition(offset: range.start), isEnd: isEnd);
-          return SelectionResult.previous;
-        }
-        if (!forwardSelection &&
-            adjustedPositionRelativeToOriginParagraph.offset >=
-                originParagraphPlaceholderRange.end) {
-          _setSelectionPosition(existingSelectionEnd, isEnd: false);
-          _setSelectionPosition(TextPosition(offset: range.end), isEnd: isEnd);
-          return SelectionResult.next;
-        }
-        if (forwardSelection &&
-            adjustedPositionRelativeToOriginParagraph.offset >=
-                originParagraphPlaceholderRange.end) {
-          _setSelectionPosition(TextPosition(offset: range.end), isEnd: isEnd);
-          return SelectionResult.next;
-        }
-        if (!forwardSelection &&
-            adjustedPositionRelativeToOriginParagraph.offset <=
-                originParagraphPlaceholderRange.start) {
-          _setSelectionPosition(TextPosition(offset: range.start), isEnd: isEnd);
-          return SelectionResult.previous;
-        }
-      }
-    } else {
+    {
       // When the drag position is somewhere on the root text and not a placeholder,
       // traverse the selectable fragments relative to the [RenderParagraph] that
       // contains the drag position.
@@ -3003,35 +2347,6 @@ class _SelectableFragment
     return false;
   }
 
-  RenderParagraph _getOriginParagraph() {
-    // This method should only be called from a fragment that contains
-    // the origin boundary. By traversing up the RenderTree, determine the
-    // highest RenderParagraph that contains the origin text boundary.
-    assert(_selectableContainsOriginTextBoundary);
-    // Begin at the parent because it is guaranteed the paragraph containing
-    // this selectable fragment contains the origin boundary.
-    RenderObject? current = paragraph.parent;
-    RenderParagraph? originParagraph;
-    while (current != null) {
-      if (current is RenderParagraph) {
-        if (current._lastSelectableFragments != null) {
-          var paragraphContainsOriginTextBoundary = false;
-          for (final _SelectableFragment fragment in current._lastSelectableFragments!) {
-            if (fragment._selectableContainsOriginTextBoundary) {
-              paragraphContainsOriginTextBoundary = true;
-              originParagraph = current;
-              break;
-            }
-          }
-          if (!paragraphContainsOriginTextBoundary) {
-            return originParagraph ?? paragraph;
-          }
-        }
-      }
-      current = current.parent;
-    }
-    return originParagraph ?? paragraph;
-  }
 
   ({RenderParagraph paragraph, Offset localPosition})? _getParagraphContainingPosition(
     Offset globalPosition,
@@ -3093,7 +2408,6 @@ class _SelectableFragment
   SelectionResult _handleClearSelection() {
     _textSelectionStart = null;
     _textSelectionEnd = null;
-    _selectableContainsOriginTextBoundary = false;
     return SelectionResult.none;
   }
 
@@ -3123,7 +2437,6 @@ class _SelectableFragment
     );
     _textSelectionStart = textBoundary.boundaryStart;
     _textSelectionEnd = textBoundary.boundaryEnd;
-    _selectableContainsOriginTextBoundary = true;
     return SelectionResult.end;
   }
 
@@ -3159,7 +2472,6 @@ class _SelectableFragment
     if (intersectRange != null) {
       _textSelectionStart = TextPosition(offset: intersectRange.start);
       _textSelectionEnd = TextPosition(offset: intersectRange.end);
-      _selectableContainsOriginTextBoundary = true;
       if (range.end < textBoundary.boundaryEnd.offset) {
         return SelectionResult.next;
       }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1672,26 +1672,30 @@ class _SelectableFragment
     TextPosition? existingSelectionStart,
     TextPosition? existingSelectionEnd,
   ) {
-    TextPosition? targetPosition;
-    if (textBoundary != null) {
-      assert(
-        textBoundary.boundaryStart.offset >= range.start &&
-            textBoundary.boundaryEnd.offset <= range.end,
-      );
-      if (existingSelectionEnd != null) {
-        // If the end edge exists and the start edge is being moved, then the
-        // start edge is moved to encompass the entire text boundary at the new position.
-        if (position.offset < existingSelectionEnd.offset) {
-          targetPosition = textBoundary.boundaryStart;
-        } else {
-          targetPosition = textBoundary.boundaryEnd;
-        }
-      } else {
-        // Move the start edge to the closest text boundary.
-        targetPosition = _closestTextBoundary(textBoundary, position);
-      }
+    if (textBoundary == null) {
+      // The position is not contained within the current rect. The targetPosition
+      // will either be at the end or beginning of the current rect. See [SelectionUtils.adjustDragOffset]
+      // for a more in depth explanation on this adjustment.
+      return position;
     }
-    return targetPosition ?? position;
+    assert(
+      textBoundary.boundaryStart.offset >= range.start &&
+          textBoundary.boundaryEnd.offset <= range.end,
+    );
+    TextPosition? targetPosition;
+    if (existingSelectionEnd != null) {
+      // If the end edge exists and the start edge is being moved, then the
+      // start edge is moved to encompass the entire text boundary at the new position.
+      if (position.offset < existingSelectionEnd.offset) {
+        targetPosition = textBoundary.boundaryStart;
+      } else {
+        targetPosition = textBoundary.boundaryEnd;
+      }
+    } else {
+      // Move the start edge to the closest text boundary.
+      targetPosition = _closestTextBoundary(textBoundary, position);
+    }
+    return targetPosition;
   }
 
   TextPosition _updateSelectionEndEdgeByTextBoundary(
@@ -1701,26 +1705,30 @@ class _SelectableFragment
     TextPosition? existingSelectionStart,
     TextPosition? existingSelectionEnd,
   ) {
-    TextPosition? targetPosition;
-    if (textBoundary != null) {
-      assert(
-        textBoundary.boundaryStart.offset >= range.start &&
-            textBoundary.boundaryEnd.offset <= range.end,
-      );
-      if (existingSelectionStart != null) {
-        // If the start edge exists and the end edge is being moved, then the
-        // end edge is moved to encompass the entire text boundary at the new position.
-        if (position.offset < existingSelectionStart.offset) {
-          targetPosition = textBoundary.boundaryStart;
-        } else {
-          targetPosition = textBoundary.boundaryEnd;
-        }
-      } else {
-        // Move the end edge to the closest text boundary.
-        targetPosition = _closestTextBoundary(textBoundary, position);
-      }
+    if (textBoundary == null) {
+      // The position is not contained within the current rect. The targetPosition
+      // will either be at the end or beginning of the current rect. See [SelectionUtils.adjustDragOffset]
+      // for a more in depth explanation on this adjustment.
+      return position;
     }
-    return targetPosition ?? position;
+    assert(
+      textBoundary.boundaryStart.offset >= range.start &&
+          textBoundary.boundaryEnd.offset <= range.end,
+    );
+    TextPosition? targetPosition;
+    if (existingSelectionStart != null) {
+      // If the start edge exists and the end edge is being moved, then the
+      // end edge is moved to encompass the entire text boundary at the new position.
+      if (position.offset < existingSelectionStart.offset) {
+        targetPosition = textBoundary.boundaryStart;
+      } else {
+        targetPosition = textBoundary.boundaryEnd;
+      }
+    } else {
+      // Move the end edge to the closest text boundary.
+      targetPosition = _closestTextBoundary(textBoundary, position);
+    }
+    return targetPosition;
   }
 
   SelectionResult _updateSelectionEdgeByTextBoundary(
@@ -2346,7 +2354,6 @@ class _SelectableFragment
     }
     return false;
   }
-
 
   ({RenderParagraph paragraph, Offset localPosition})? _getParagraphContainingPosition(
     Offset globalPosition,

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2135,19 +2135,9 @@ class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainer
     }
   }
 
-  /// Updates the internal selection state after a [SelectionEvent] that
-  /// selects a boundary such as: [SelectWordSelectionEvent],
-  /// [SelectParagraphSelectionEvent], and [SelectAllSelectionEvent].
-  ///
-  /// Call this method after determining the new selection as a result of
-  /// a [SelectionEvent] that selects a boundary. The [currentSelectionStartIndex]
-  /// and [currentSelectionEndIndex] should be set to valid values at the time
-  /// this method is called.
-  ///
-  /// Subclasses should call [clearInternalSelectionStateForSelectable] to clean up any state
-  /// added by this method, for example when removing a [Selectable] from this delegate.
-  @protected
+  @override
   void didReceiveSelectionBoundaryEvents() {
+    super.didReceiveSelectionBoundaryEvents();
     if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
       return;
     }
@@ -2237,26 +2227,11 @@ class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainer
     super.remove(selectable);
   }
 
-  @override
-  SelectionResult handleSelectAll(SelectAllSelectionEvent event) {
-    final SelectionResult result = super.handleSelectAll(event);
-    didReceiveSelectionBoundaryEvents();
-    return result;
-  }
-
-  @override
-  SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
-    final SelectionResult result = super.handleSelectWord(event);
-    didReceiveSelectionBoundaryEvents();
-    return result;
-  }
-
-  @override
-  SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
-    final SelectionResult result = super.handleSelectParagraph(event);
-    didReceiveSelectionBoundaryEvents();
-    return result;
-  }
+  // handleSelectAll, handleSelectWord, and handleSelectParagraph are inherited
+  // from MultiSelectableSelectionContainerDelegate, which calls
+  // didReceiveSelectionBoundaryEvents() after each. The override in this class
+  // adds event-receipt tracking and edge location capture on top of the base
+  // origin capture.
 
   @override
   SelectionResult handleClearSelection(ClearSelectionEvent event) {
@@ -2557,48 +2532,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       currentSelectionStartIndex -= 1;
     }
     selectable.removeListener(_handleSelectableGeometryChange);
-  }
-
-  /// Records the selectables in the current selection range as origin
-  /// boundary selectables and captures the boundary edge positions.
-  ///
-  /// Call this after [currentSelectionStartIndex] and [currentSelectionEndIndex]
-  /// have been set as the result of a [SelectWordSelectionEvent] or
-  /// [SelectParagraphSelectionEvent].
-  @protected
-  void captureOriginSelectables() {
-    clearOriginSelectables();
-    if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
-      return;
-    }
-    final int start = min(currentSelectionStartIndex, currentSelectionEndIndex);
-    final int end = max(currentSelectionStartIndex, currentSelectionEndIndex);
-    for (int i = start; i <= end; i++) {
-      _originSelectables.add(selectables[i]);
-    }
-    // Capture the origin boundary edge positions in local coordinates.
-    // These are converted to global on demand so they remain valid after scroll.
-    final Selectable startSelectable = selectables[start];
-    final SelectionPoint? startPoint = startSelectable.value.startSelectionPoint;
-    if (startPoint != null) {
-      _originStartSelectable = startSelectable;
-      _originStartLocalPosition = startPoint.localPosition + Offset(0, -startPoint.lineHeight / 2);
-    }
-    final Selectable endSelectable = selectables[end];
-    final SelectionPoint? endPoint = endSelectable.value.endSelectionPoint;
-    if (endPoint != null) {
-      _originEndSelectable = endSelectable;
-      _originEndLocalPosition = endPoint.localPosition + Offset(0, -endPoint.lineHeight / 2);
-    }
-    // Capture the content-relative offsets of the origin boundary.
-    final SelectedContentRange? startRange = startSelectable.getSelection();
-    if (startRange != null) {
-      _originStartOffset = min(startRange.startOffset, startRange.endOffset);
-    }
-    final SelectedContentRange? endRange = endSelectable.getSelection();
-    if (endRange != null) {
-      _originEndOffset = max(endRange.startOffset, endRange.endOffset);
-    }
   }
 
   /// Whether the given [selectable] is part of the origin text boundary.
@@ -3043,6 +2976,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     }
     currentSelectionStartIndex = 0;
     currentSelectionEndIndex = selectables.length - 1;
+    didReceiveSelectionBoundaryEvents();
     return SelectionResult.none;
   }
 
@@ -3054,6 +2988,55 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
         continue;
       }
       dispatchSelectionEventToChild(selectables[i], const ClearSelectionEvent());
+    }
+  }
+
+  /// Called after a boundary selection event ([SelectWordSelectionEvent],
+  /// [SelectParagraphSelectionEvent], or [SelectAllSelectionEvent]) has been
+  /// handled and [currentSelectionStartIndex]/[currentSelectionEndIndex] have
+  /// been set.
+  ///
+  /// The base implementation captures origin text boundary state for the
+  /// selection anchoring feature. Subclasses that override this method must
+  /// call super.
+  @protected
+  @mustCallSuper
+  void didReceiveSelectionBoundaryEvents() {
+    _captureOriginState();
+  }
+
+  void _captureOriginState() {
+    clearOriginSelectables();
+    if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
+      return;
+    }
+    final int start = min(currentSelectionStartIndex, currentSelectionEndIndex);
+    final int end = max(currentSelectionStartIndex, currentSelectionEndIndex);
+    for (int i = start; i <= end; i++) {
+      _originSelectables.add(selectables[i]);
+    }
+    // Capture the origin boundary edge positions in local coordinates.
+    // These are converted to global on demand so they remain valid after scroll.
+    final Selectable startSelectable = selectables[start];
+    final SelectionPoint? startPoint = startSelectable.value.startSelectionPoint;
+    if (startPoint != null) {
+      _originStartSelectable = startSelectable;
+      _originStartLocalPosition = startPoint.localPosition + Offset(0, -startPoint.lineHeight / 2);
+    }
+    final Selectable endSelectable = selectables[end];
+    final SelectionPoint? endPoint = endSelectable.value.endSelectionPoint;
+    if (endPoint != null) {
+      _originEndSelectable = endSelectable;
+      _originEndLocalPosition = endPoint.localPosition + Offset(0, -endPoint.lineHeight / 2);
+    }
+    // Capture the content-relative offsets of the origin boundary.
+    final SelectedContentRange? startRange = startSelectable.getSelection();
+    if (startRange != null) {
+      _originStartOffset = min(startRange.startOffset, startRange.endOffset);
+    }
+    final SelectedContentRange? endRange = endSelectable.getSelection();
+    if (endRange != null) {
+      _originEndOffset = max(endRange.startOffset, endRange.endOffset);
     }
   }
 
@@ -3139,7 +3122,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   @protected
   SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
     final SelectionResult result = _handleSelectBoundary(event);
-    captureOriginSelectables();
+    didReceiveSelectionBoundaryEvents();
     return result;
   }
 
@@ -3148,7 +3131,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   @protected
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = _handleSelectBoundary(event);
-    captureOriginSelectables();
+    didReceiveSelectionBoundaryEvents();
     return result;
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2409,6 +2409,24 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
 
   bool _extendSelectionInProgress = false;
 
+  // Origin text boundary tracking.
+  //
+  // When a word or paragraph is selected (e.g. double-click), these fields
+  // record which selectables are part of the origin boundary and the positions
+  // of its edges. During subsequent drag, this enables the container to keep
+  // the origin boundary anchored in the selection — analogous to Chromium's
+  // SelectionModifier::PrepareToModifySelection anchor normalization.
+  final Set<Selectable> _originSelectables = <Selectable>{};
+  Selectable? _originStartSelectable;
+  Offset? _originStartLocalPosition;
+  Selectable? _originEndSelectable;
+  Offset? _originEndLocalPosition;
+  // The content-relative offsets of the origin boundary on the start/end
+  // selectables. Used to detect when the selection has collapsed at the
+  // origin boundary during paragraph-granularity drags.
+  int? _originStartOffset;
+  int? _originEndOffset;
+
   @override
   void add(Selectable selectable) {
     assert(!selectables.contains(selectable));
@@ -2521,6 +2539,15 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
 
   void _removeSelectable(Selectable selectable) {
     assert(selectables.contains(selectable), 'The selectable is not in this registrar.');
+    _originSelectables.remove(selectable);
+    if (_originStartSelectable == selectable) {
+      _originStartSelectable = null;
+      _originStartLocalPosition = null;
+    }
+    if (_originEndSelectable == selectable) {
+      _originEndSelectable = null;
+      _originEndLocalPosition = null;
+    }
     final int index = selectables.indexOf(selectable);
     selectables.removeAt(index);
     if (index <= currentSelectionEndIndex) {
@@ -2530,6 +2557,64 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       currentSelectionStartIndex -= 1;
     }
     selectable.removeListener(_handleSelectableGeometryChange);
+  }
+
+  /// Records the selectables in the current selection range as origin
+  /// boundary selectables and captures the boundary edge positions.
+  ///
+  /// Call this after [currentSelectionStartIndex] and [currentSelectionEndIndex]
+  /// have been set as the result of a [SelectWordSelectionEvent] or
+  /// [SelectParagraphSelectionEvent].
+  @protected
+  void captureOriginSelectables() {
+    clearOriginSelectables();
+    if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
+      return;
+    }
+    final int start = min(currentSelectionStartIndex, currentSelectionEndIndex);
+    final int end = max(currentSelectionStartIndex, currentSelectionEndIndex);
+    for (int i = start; i <= end; i++) {
+      _originSelectables.add(selectables[i]);
+    }
+    // Capture the origin boundary edge positions in local coordinates.
+    // These are converted to global on demand so they remain valid after scroll.
+    final Selectable startSelectable = selectables[start];
+    final SelectionPoint? startPoint = startSelectable.value.startSelectionPoint;
+    if (startPoint != null) {
+      _originStartSelectable = startSelectable;
+      _originStartLocalPosition = startPoint.localPosition + Offset(0, -startPoint.lineHeight / 2);
+    }
+    final Selectable endSelectable = selectables[end];
+    final SelectionPoint? endPoint = endSelectable.value.endSelectionPoint;
+    if (endPoint != null) {
+      _originEndSelectable = endSelectable;
+      _originEndLocalPosition = endPoint.localPosition + Offset(0, -endPoint.lineHeight / 2);
+    }
+    // Capture the content-relative offsets of the origin boundary.
+    final SelectedContentRange? startRange = startSelectable.getSelection();
+    if (startRange != null) {
+      _originStartOffset = min(startRange.startOffset, startRange.endOffset);
+    }
+    final SelectedContentRange? endRange = endSelectable.getSelection();
+    if (endRange != null) {
+      _originEndOffset = max(endRange.startOffset, endRange.endOffset);
+    }
+  }
+
+  /// Whether the given [selectable] is part of the origin text boundary.
+  @protected
+  bool isOriginSelectable(Selectable selectable) => _originSelectables.contains(selectable);
+
+  /// Clears all origin text boundary tracking state.
+  @protected
+  void clearOriginSelectables() {
+    _originSelectables.clear();
+    _originStartSelectable = null;
+    _originStartLocalPosition = null;
+    _originEndSelectable = null;
+    _originEndLocalPosition = null;
+    _originStartOffset = null;
+    _originEndOffset = null;
   }
 
   /// Called when this delegate finishes updating the [Selectable]s.
@@ -2943,6 +3028,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       if (index >= skipStart && index <= skipEnd) {
         continue;
       }
+      if (_originSelectables.contains(selectables[index])) {
+        continue;
+      }
       dispatchSelectionEventToChild(selectables[index], const ClearSelectionEvent());
     }
   }
@@ -3050,19 +3138,24 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// [SelectWordSelectionEvent.globalPosition].
   @protected
   SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
-    return _handleSelectBoundary(event);
+    final SelectionResult result = _handleSelectBoundary(event);
+    captureOriginSelectables();
+    return result;
   }
 
   /// Selects a paragraph in a [Selectable] at the location
   /// [SelectParagraphSelectionEvent.globalPosition].
   @protected
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
-    return _handleSelectBoundary(event);
+    final SelectionResult result = _handleSelectBoundary(event);
+    captureOriginSelectables();
+    return result;
   }
 
   /// Removes the selection of all [Selectable]s this delegate manages.
   @protected
   SelectionResult handleClearSelection(ClearSelectionEvent event) {
+    clearOriginSelectables();
     for (final Selectable selectable in selectables) {
       dispatchSelectionEventToChild(selectable, event);
     }
@@ -3211,6 +3304,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
 
   @override
   void dispose() {
+    clearOriginSelectables();
     for (final Selectable selectable in selectables) {
       selectable.removeListener(_handleSelectableGeometryChange);
     }
@@ -3233,9 +3327,121 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   ///
   /// Override this method if subclasses need to generate additional events or
   /// treatments prior to sending the [SelectionEvent].
+  ///
+  /// For origin selectables during text boundary drags (word/paragraph
+  /// granularity), this method dispatches a corrective edge event after the
+  /// original event to maintain the origin boundary anchor — analogous to
+  /// Chromium's `SelectionModifier::PrepareToModifySelection`.
   @protected
   SelectionResult dispatchSelectionEventToChild(Selectable selectable, SelectionEvent event) {
-    return selectable.dispatchSelectionEvent(event);
+    final SelectionResult result = selectable.dispatchSelectionEvent(event);
+    if (!_isApplyingOriginCorrection &&
+        event is SelectionEdgeUpdateEvent &&
+        event.granularity != TextGranularity.character &&
+        _originSelectables.contains(selectable)) {
+      _correctOriginSelectable(selectable, event);
+    }
+    return result;
+  }
+
+  // Prevents recursive origin correction across nested delegates.
+  // When an outer delegate's corrective event propagates through an inner
+  // delegate (e.g., SelectableRegion → Text widget → fragment), the inner
+  // delegate must not fire its own correction for the outer's corrective event.
+  static bool _isApplyingOriginCorrection = false;
+
+  /// Dispatches a corrective edge event to an origin selectable to maintain
+  /// the origin text boundary anchor.
+  ///
+  /// After the moving edge is updated normally, this method sets the static
+  /// (anchor) edge to the appropriate origin boundary position. Which boundary
+  /// end is used as the anchor depends on the selection direction:
+  ///
+  /// * Forward selection (end ≥ start): anchor at origin start
+  /// * Inverted selection (end < start): anchor at origin end
+  ///
+  /// This mirrors Chromium's `PrepareToModifySelection`, which picks the
+  /// anchor position (wordStart or wordEnd) based on extension direction.
+  void _correctOriginSelectable(Selectable selectable, SelectionEdgeUpdateEvent event) {
+    _isApplyingOriginCorrection = true;
+    try {
+      _correctOriginSelectableImpl(selectable, event);
+    } finally {
+      _isApplyingOriginCorrection = false;
+    }
+  }
+
+  void _correctOriginSelectableImpl(Selectable selectable, SelectionEdgeUpdateEvent event) {
+    // If the selectable lost its selection entirely, restore it.
+    if (!selectable.value.hasSelection) {
+      selectable.dispatchSelectionEvent(const SelectAllSelectionEvent());
+      return;
+    }
+    final SelectedContentRange? range = selectable.getSelection();
+    if (range == null) {
+      return;
+    }
+    if (_originStartSelectable == null ||
+        _originStartLocalPosition == null ||
+        _originEndSelectable == null ||
+        _originEndLocalPosition == null) {
+      return;
+    }
+    final bool isEndEdge = event.type == SelectionEventType.endEdgeUpdate;
+    // Detect inversion: the moving edge has crossed the origin boundary.
+    // This includes an "implicit inversion" case where the standard paragraph
+    // boundary logic sets the moving edge to a position that coincides with
+    // the origin boundary start/end, producing a collapsed selection. In this
+    // case the offset comparison catches what the standard < check misses.
+    bool isInverted = range.endOffset < range.startOffset;
+    if (!isInverted && _originStartOffset != null && _originEndOffset != null) {
+      if (isEndEdge && range.endOffset <= _originStartOffset!) {
+        isInverted = true;
+      } else if (!isEndEdge && range.startOffset >= _originEndOffset!) {
+        isInverted = true;
+      }
+    }
+    // Compute the anchor global position on demand (handles scroll).
+    final Offset originStartGlobal = MatrixUtils.transformPoint(
+      _originStartSelectable!.getTransformTo(null),
+      _originStartLocalPosition!,
+    );
+    final Offset originEndGlobal = MatrixUtils.transformPoint(
+      _originEndSelectable!.getTransformTo(null),
+      _originEndLocalPosition!,
+    );
+    // The anchor is the origin boundary edge opposite to the drag direction.
+    // When moving the END edge:
+    //   - Not inverted (forward): anchor START at originStart
+    //   - Inverted (backward):    anchor START at originEnd
+    // When moving the START edge:
+    //   - Not inverted (forward): anchor END at originEnd
+    //   - Inverted (backward):    anchor END at originStart
+    // Use character granularity for the corrective event so the anchor is
+    // placed at the exact captured position without word/paragraph boundary
+    // snapping. This avoids the off-by-one issue where the origin boundary
+    // end (e.g., offset 11) sits at a word boundary seam and would resolve
+    // to the NEXT word boundary if using word granularity.
+    if (isEndEdge) {
+      final anchorGlobal = isInverted ? originEndGlobal : originStartGlobal;
+      selectable.dispatchSelectionEvent(
+        SelectionEdgeUpdateEvent.forStart(globalPosition: anchorGlobal),
+      );
+      if (isInverted) {
+        // Re-dispatch the original event so the standard boundary logic
+        // sees the corrected anchor and computes the correct boundary
+        // direction (backward instead of forward).
+        selectable.dispatchSelectionEvent(event);
+      }
+    } else {
+      final anchorGlobal = isInverted ? originStartGlobal : originEndGlobal;
+      selectable.dispatchSelectionEvent(
+        SelectionEdgeUpdateEvent.forEnd(globalPosition: anchorGlobal),
+      );
+      if (isInverted) {
+        selectable.dispatchSelectionEvent(event);
+      }
+    }
   }
 
   /// Initializes the selection of the selectable children.

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -1114,108 +1114,6 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
     return SelectionResult.end;
   }
 
-  SelectionResult _adjustSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
-    assert(() {
-      if (isEnd) {
-        assert(currentSelectionEndIndex < selectables.length && currentSelectionEndIndex >= 0);
-        return true;
-      }
-      assert(currentSelectionStartIndex < selectables.length && currentSelectionStartIndex >= 0);
-      return true;
-    }());
-    SelectionResult? finalResult;
-    // Determines if the edge being adjusted is within the current viewport.
-    //  - If so, we begin the search for the new selection edge position at the
-    //    currentSelectionEndIndex/currentSelectionStartIndex.
-    //  - If not, we attempt to locate the new selection edge starting from
-    //    the opposite end.
-    //  - If neither edge is in the current viewport, the search for the new
-    //    selection edge position begins at 0.
-    //
-    // This can happen when there is a scrollable child and the edge being adjusted
-    // has been scrolled out of view.
-    final isCurrentEdgeWithinViewport = isEnd
-        ? value.endSelectionPoint != null
-        : value.startSelectionPoint != null;
-    final isOppositeEdgeWithinViewport = isEnd
-        ? value.startSelectionPoint != null
-        : value.endSelectionPoint != null;
-    int newIndex = switch ((isEnd, isCurrentEdgeWithinViewport, isOppositeEdgeWithinViewport)) {
-      (true, true, true) => currentSelectionEndIndex,
-      (true, true, false) => currentSelectionEndIndex,
-      (true, false, true) => currentSelectionStartIndex,
-      (true, false, false) => 0,
-      (false, true, true) => currentSelectionStartIndex,
-      (false, true, false) => currentSelectionStartIndex,
-      (false, false, true) => currentSelectionEndIndex,
-      (false, false, false) => 0,
-    };
-    bool? forward;
-    late SelectionResult currentSelectableResult;
-    // This loop sends the selection event to one of the following to determine
-    // the direction of the search.
-    //  - currentSelectionEndIndex/currentSelectionStartIndex if the current edge
-    //    is in the current viewport.
-    //  - The opposite edge index if the current edge is not in the current viewport.
-    //  - Index 0 if neither edge is in the current viewport.
-    //
-    // If the result is `SelectionResult.next`, this loop look backward.
-    // Otherwise, it looks forward.
-    //
-    // The terminate condition are:
-    // 1. the selectable returns end, pending, none.
-    // 2. the selectable returns previous when looking forward.
-    // 2. the selectable returns next when looking backward.
-    while (newIndex < selectables.length && newIndex >= 0 && finalResult == null) {
-      currentSelectableResult = dispatchSelectionEventToChild(selectables[newIndex], event);
-      switch (currentSelectableResult) {
-        case SelectionResult.end:
-        case SelectionResult.pending:
-        case SelectionResult.none:
-          finalResult = currentSelectableResult;
-        case SelectionResult.next:
-          if (forward == false) {
-            newIndex += 1;
-            finalResult = SelectionResult.end;
-          } else if (newIndex == selectables.length - 1) {
-            finalResult = currentSelectableResult;
-          } else {
-            forward = true;
-            newIndex += 1;
-          }
-        case SelectionResult.previous:
-          if (forward ?? false) {
-            newIndex -= 1;
-            finalResult = SelectionResult.end;
-          } else if (newIndex == 0) {
-            finalResult = currentSelectableResult;
-          } else {
-            forward = false;
-            newIndex -= 1;
-          }
-      }
-    }
-    if (isEnd) {
-      final bool forwardSelection = currentSelectionEndIndex >= currentSelectionStartIndex;
-      if (forward != null &&
-          ((!forwardSelection && forward && newIndex >= currentSelectionStartIndex) ||
-              (forwardSelection && !forward && newIndex <= currentSelectionStartIndex))) {
-        currentSelectionStartIndex = currentSelectionEndIndex;
-      }
-      currentSelectionEndIndex = newIndex;
-    } else {
-      final bool forwardSelection = currentSelectionEndIndex >= currentSelectionStartIndex;
-      if (forward != null &&
-          ((!forwardSelection && !forward && newIndex <= currentSelectionEndIndex) ||
-              (forwardSelection && forward && newIndex >= currentSelectionEndIndex))) {
-        currentSelectionEndIndex = currentSelectionStartIndex;
-      }
-      currentSelectionStartIndex = newIndex;
-    }
-    _flushInactiveSelections();
-    return finalResult!;
-  }
-
   /// The compare function this delegate used for determining the selection
   /// order of the [Selectable]s.
   ///
@@ -1397,25 +1295,6 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
       }
       dispatchSelectionEventToChild(selectables[index], const ClearSelectionEvent());
     }
-  }
-
-  @override
-  SelectionResult handleSelectionEdgeUpdate(SelectionEdgeUpdateEvent event) {
-    if (event.granularity != TextGranularity.paragraph) {
-      return super.handleSelectionEdgeUpdate(event);
-    }
-    updateLastSelectionEdgeLocation(
-      globalSelectionEdgeLocation: event.globalPosition,
-      forEnd: event.type == SelectionEventType.endEdgeUpdate,
-    );
-    if (event.type == SelectionEventType.endEdgeUpdate) {
-      return currentSelectionEndIndex == -1
-          ? super.handleSelectionEdgeUpdate(event)
-          : _adjustSelection(event, isEnd: true);
-    }
-    return currentSelectionStartIndex == -1
-        ? super.handleSelectionEdgeUpdate(event)
-        : _adjustSelection(event, isEnd: false);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -996,7 +996,6 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = _handleSelectParagraph(event);
     super.didReceiveSelectionBoundaryEvents();
-    captureOriginSelectables();
     return result;
   }
 

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -996,6 +996,7 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = _handleSelectParagraph(event);
     super.didReceiveSelectionBoundaryEvents();
+    captureOriginSelectables();
     return result;
   }
 
@@ -1390,6 +1391,9 @@ class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate 
     final int skipEnd = max(currentSelectionStartIndex, currentSelectionEndIndex);
     for (var index = 0; index < selectables.length; index += 1) {
       if (index >= skipStart && index <= skipEnd) {
+        continue;
+      }
+      if (isOriginSelectable(selectables[index])) {
         continue;
       }
       dispatchSelectionEventToChild(selectables[index], const ClearSelectionEvent());


### PR DESCRIPTION
This change refactors the logic that would keep the origin boundary anchored to the selection, for example a word boundary during a double-click drag or a paragraph boundary during a triple-click drag. It moves it out of `RenderParagraph` where only `Selectable`s that were a `RenderParagraph` could benefit from the anchoring, and into the selection delegate level where all `Selectable`s can receive the anchoring automatically.

This fixes issues where if a `Selectable` that is not a `RenderParagraph` inside a `WidgetSpan` of a `RenderParagraph` contained part of the origin boundary, it had no way to anchor its local boundary across various selection updates (selection inversion for example).
